### PR TITLE
Refactor filters into filter backends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: install
           command: |
-              pacman -Syu --noconfirm --needed base-devel asciidoctor go bash-bats
+              pacman -Syu --noconfirm --needed base-devel asciidoctor go jq openssh git bash-bats
       - run:
           name: clitest
           command: |

--- a/bin/hr/color.go
+++ b/bin/hr/color.go
@@ -1,0 +1,22 @@
+package main
+
+const (
+	colorNop    = ""
+	colorReset  = "\033[0m"
+	colorBold   = "\033[1m"
+	colorRed    = "\033[31m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorBlue   = "\033[34m"
+	colorPurple = "\033[35m"
+	colorCyan   = "\033[36m"
+	colorWhite  = "\033[37m"
+	colorGray   = "\033[0;38;5;245m"
+)
+
+func colorize(color, s string) string {
+	if color == colorNop {
+		return s
+	}
+	return color + s + colorReset
+}

--- a/bin/hr/filter.go
+++ b/bin/hr/filter.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	filterTypeSimple = iota
+	filterTypeJQ
+)
+
+type filter struct {
+	ftype      int
+	simpleSpec filterSimple
+	priority   int
+}
+
+func (f *filter) filter(line map[string]interface{}) (map[string]interface{}, error) {
+	switch f.ftype {
+	case filterTypeSimple:
+		if f.simpleSpec.isMatch(line) {
+			return line, nil
+		}
+		return nil, nil
+	}
+	panic("BUG: invalid filter type")
+}
+
+func determineFilterType(spec string) int {
+	return filterTypeSimple
+}
+
+type filterSimple struct {
+	filename     string
+	components   []string
+	messageTypes []string
+}
+
+func parseSimpleFilter(filterexpr string) (*filter, error) {
+	var (
+		res   filterSimple
+		parts = strings.SplitN(filterexpr, ":", 3)
+	)
+	switch len(parts) {
+	// Only a filename ist specified, no filters.
+	case 1:
+		res.filename = parts[0]
+	// Filters and filename is availabe.
+	case 2:
+		res.messageTypes = removeEmpy(strings.Split(parts[0], ","))
+		res.filename = parts[1]
+	// Components, filters, and a filename specified.
+	case 3:
+		res.components = removeEmpy(strings.Split(parts[0], ","))
+		res.messageTypes = removeEmpy(strings.Split(parts[1], ","))
+		res.filename = parts[2]
+	// Filter expression is invalid.
+	default:
+		return nil, fmt.Errorf("invalid filter expression")
+	}
+	return &filter{ftype: filterTypeSimple, simpleSpec: res}, nil
+}
+
+func compare(candidate string, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	c := strings.ToLower(candidate)
+	for _, filter := range filters {
+		f := strings.ToLower(filter)
+		if c == f {
+			return true
+		}
+	}
+	return false
+}
+
+// FIXME: exclusive is broken, thus missing
+func (f *filterSimple) isMatch(data map[string]interface{}) bool {
+	comp, err := castField(data, "component")
+	if err != nil {
+		return false
+	}
+	msgType, err := castField(data, "type")
+	if err != nil {
+		return false
+	}
+	if !compare(comp, f.components) {
+		return false
+	}
+	if !compare(msgType, f.messageTypes) {
+		return false
+	}
+	return true
+}

--- a/bin/hr/helper.go
+++ b/bin/hr/helper.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"golang.org/x/sys/unix"
+)
+
+func padOrTruncate(s string, maxLen int) string {
+	res := s
+	if len(s) > maxLen {
+		res = s[:maxLen]
+	} else if len(s) < maxLen {
+		res += strings.Repeat(" ", maxLen-len(s))
+	}
+	return res
+}
+
+func isatty(fd uintptr) bool {
+	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	return err == nil
+}
+
+func castField(data map[string]interface{}, field string) (string, error) {
+	if vIface, ok := data[field]; ok {
+		if vString, ok := vIface.(string); ok {
+			return vString, nil
+		}
+		return "", fmt.Errorf("%w: field '%s' is not a string", errInvalidData, field)
+	}
+	return "", fmt.Errorf("%w: field '%s' does not exist in data", errInvalidData, field)
+}
+
+func logError(w *bufio.Writer, msg string) {
+	var line = map[string]string{
+		"timestamp": time.Now().Format("2006-01-02T15:04:05.000000"),
+		"data":      msg,
+		"component": "JSON",
+		"type":      "ERROR",
+	}
+	str, _ := json.Marshal(line)
+	w.Write(str)
+	w.WriteRune('\n')
+}
+
+func removeEmpy(data []string) []string {
+	b := data[:0]
+	for _, x := range data {
+		x = strings.TrimSpace(x)
+		if x != "" {
+			b = append(b, x)
+		}
+	}
+	return b
+}
+
+func getReader(filename string) io.Reader {
+	var reader io.Reader
+	file, err := os.Open(filename)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	switch filepath.Ext(filename) {
+	case ".gz":
+		reader, err = gzip.NewReader(file)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	case ".zst":
+		reader, err = zstd.NewReader(file)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	default:
+		reader = file
+	}
+	return reader
+}
+
+func copyData(data map[string]interface{}) map[string]interface{} {
+	d := make(map[string]interface{})
+	for k, v := range data {
+		d[k] = v
+	}
+	return d
+}
+
+type broadcaster struct {
+	inCh   chan map[string]interface{}
+	outChs []chan map[string]interface{}
+	wg     *sync.WaitGroup
+}
+
+func (bc *broadcaster) serve() {
+	for data := range bc.inCh {
+		for _, listener := range bc.outChs {
+			d := copyData(data)
+			listener <- d
+		}
+	}
+	for _, ch := range bc.outChs {
+		close(ch)
+	}
+	bc.wg.Done()
+}

--- a/bin/hr/hr.go
+++ b/bin/hr/hr.go
@@ -89,7 +89,7 @@ func (c *converter) cleanup() {
 
 func (c *converter) addFilterSpecs(specs []string) {
 	for _, spec := range specs {
-		filter, err := parseFilter(spec)
+		filter, err := parseSimpleFilter(spec)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -363,7 +363,7 @@ func removeEmpy(data []string) []string {
 	return b
 }
 
-func parseFilter(filterexpr string) (map[string][]string, error) {
+func parseSimpleFilter(filterexpr string) (map[string][]string, error) {
 	var (
 		parts = strings.SplitN(filterexpr, ":", 3)
 		res   = make(map[string][]string)

--- a/tests/cli/0001-hr-check.bats
+++ b/tests/cli/0001-hr-check.bats
@@ -47,7 +47,7 @@ setup() {
 	local out
 	echo "$data" | hr "${HRFLAGS[@]}" -f "$BATS_TMPDIR/foo.log" > /dev/null
 	out="$(cat $BATS_TMPDIR/foo.log)"
-	compstr "$out" "$data"
+	compjson "$out" "$data"
 	rm "$BATS_TMPDIR/foo.log"
 }
 
@@ -56,8 +56,8 @@ setup() {
 	echo "$data" | hr "${HRFLAGS[@]}" -f "$BATS_TMPDIR/foo.log" -f "$BATS_TMPDIR/foo2.log" > /dev/null
 	out="$(cat $BATS_TMPDIR/foo.log)"
 	out2="$(cat $BATS_TMPDIR/foo2.log)"
-	compstr "$out" "$data"
-	compstr "$out2" "$data"
+	compjson "$out" "$data"
+	compjson "$out2" "$data"
 	rm "$BATS_TMPDIR/foo2.log"
 	rm "$BATS_TMPDIR/foo.log"
 }
@@ -66,7 +66,7 @@ setup() {
 	local out
 	echo "$data" | hr "${HRFLAGS[@]}" -f "$BATS_TMPDIR/foo.log.gz" > /dev/null
 	out="$(zcat $BATS_TMPDIR/foo.log.gz)"
-	compstr "$out" "$data"
+	compjson "$out" "$data"
 	rm "$BATS_TMPDIR/foo.log.gz"
 }
 

--- a/tests/cli/lib-helpers.bash
+++ b/tests/cli/lib-helpers.bash
@@ -10,3 +10,19 @@ compstr() {
 	fi
 	return 0
 }
+
+# $1: data
+# $2: expected data
+compjson() {
+    data="$(echo "$1" | jq -cS '.')"
+    expected="$(echo "$2" | jq -cS '.')"
+
+	if [[ "$data" != "$expected" ]]; then
+		echo "Exected data:"
+		echo "$data" | hexdump -C | head
+		echo "Got data:"
+		echo "$expected" | hexdump -C | head
+		return 1
+	fi
+	return 0
+}


### PR DESCRIPTION
Refactor filters into filter backends

This patch refactors the filters into a more generalized form. There is
now a filter data type with a .filter() method which is called in the
main loop. This way, multiple filter backends can be implemented.
Further, the jq tool can now be used as a preprocessor.